### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ## Config
 mqtt_config.py
+config.py
 
 # caches
 ff1_cache/

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Version `0.6.0` introduced a session simulator tool (found here `tools/simulatio
 >[!NOTE]
 > there are also some settings in the `simulation_run.py` tool such as `DELAY_SECONDS` which will set the speed of when it writes to the cache file.
 
->[!INFO]
+>[!NOTE]
 > The order of the simulation is: Session start, Red Bull taking lead, Yellow flag out, yellow flag cleared, safety car out, safety car in, red flag out, track clear.
 
 # Current Status
@@ -399,10 +399,6 @@ Version `0.6.0` introduced a session simulator tool (found here `tools/simulatio
 # Thank You!
 A very special thanks to all of you who has downloaded this repo and tested it! I did not expect this amount of response, so this is awesome!
 A special thanks to [@Winehorn](https://github.com/Winehorn) and [@Gtwizzy](https://github.com/Gtwizzy) for their insights and direct help and contribution
-
-# Thank You!
-A very special thanks to all of you who has downloaded this repo and tested it! I did not expect this amount of response, so this is awesome!
-A special thanks to @Winehorn and @Gtwizzy for their insights and direct help and contribution
 
 # Disclaimer
 This is a personal, non-commercial project created for fun and educational purposes. It is not affiliated with, authorized by, endorsed by, or in any way officially connected with Formula 1, the FIA, or any of their affiliates.

--- a/README.md
+++ b/README.md
@@ -26,16 +26,24 @@ To put it simply: it is a tool that I use to get an exact "here and now" picture
 * Smart lights/devices configured in Home Assistant (e.g., Philips Hue to respond to the events).
 
 ### Project Files
-Before running, you must create two configuration files:
+Before running, you must create two configuration files (easiest is to duplicate the two template files in the project and remove the `_template` suffix):
 
-1. `mqtt_config.py`: Holds your MQTT broker credentials. Create it in the root directory.
+1. `mqtt_config.py`: Holds your MQTT broker credentials.
 ```python
 MQTT_BROKER_IP = "0.0.0.0" 
 MQTT_PORT = 1883 # For unsecure communication running over local network
 MQTT_USERNAME = "service_user_name"
 MQTT_PASSWORD = "your_strong_password" # MQTT password that's also present in your Home Assistant
 ```
-2. `config.py`: Contains key variables for the service. You can edit the existing file to set your preferred initial broadcast delay and cache filename.
+2. `config.py`: Contains key variables for the service.
+```python
+CACHE_FILENAME = 'cache.txt'  # Important that this matches the one Fast-F1 Livetiming writes to
+
+PUBLISH_DELAY = 54
+
+SESSION_CACHING_ENABLED = True
+SESSION_CACHING_INTERVAL = 10
+```
 
 > [!NOTE]
 > **A Note on the `PUBLISH_DELAY`**
@@ -49,6 +57,17 @@ MQTT_PASSWORD = "your_strong_password" # MQTT password that's also present in yo
 > You'll need to fine-tune this value based on your specific broadcast: 
 > - A good-guess starting point is often between **50 and 60 seconds.** (based on personal experience)
 > - Remember, you can adjust this delay live using the **Delay Calibration** buttons in Home Assistant once the session has started.
+
+#### Caching
+To protect against unexpected crashes or interruptions, the service includes a session caching feature.
+
+* **How it works:** Every `SESSION_CACHING_INTERVAL` seconds, the service checks if the session state has changed. If it has, the current state is automatically saved to a cache file (`session_cache.pkl`) in the root directory. The state is also saved when you stop the service gracefully (e.g., with Ctrl+C).
+* **On Startup:** If the service finds this cache file, it will ask if you want to resume from the previously saved state.
+* **Purpose:** This allows you to restart the service mid-session without losing critical data, which is especially useful for tracking the fastest lap in Practice and Qualifying.
+
+When you stop the service, it will ask if the session is finished. If you confirm, the cache file will be deleted. There is no reason to keep a cache file around after a session is complete.
+
+You can also turn off the caching feature by setting `SESSION_CACHING_ENABLED` to `False`.
 
 ## Installation
 
@@ -104,7 +123,17 @@ python main.py qualifying --force-lead "Ferrari"
   * `practice`(or `p`, `fp`)
   * `qualifying`(or `q`, `"sprint qualifying"`, `sq`) 
   * `race`(or `p`, `"sprint race"`, `sr`) 
-* `--force-lead <TEAM_NAME>`**(Optional)**: Sets an initial leader state on startup. This is useful for testing automations without waiting for a leader to be established.
+* `--force-lead <TEAM_NAME>`**(Conditionally Required):** Sets an initial leader state on startup. This can be smart to use during races to ensure the leader is set in the system from the start.
+  * **Optional** for `practice` and `qualifying`
+  * **Required** for `race` sessions **unless** you are resuming from a session cache.
+
+> [!IMPORTANT]
+> **Why is `--force-lead` required for races?**
+>
+> It is *not* unthinkable that something will happen before a race lead change is detected by the service in a race (think turn 1). If there are any flags or safety cars before a lead has been detected by the service, it will **not** be able to set the correct lead team back when we go back to full racing. So say Piastri is leading down to turn 1 and your living room shines bright Papaya, then a safety car incident happens and your lights flash yellow. When the safety car goes back in the service will know to broadcast that we are back to racing conditions, but will not be able to say "oh and this is the lead".
+> 
+> Providing the P1 team at the start (e.g. `python main.py race -fl "McLaren"`) ensures your automations are correct from the moment the lights go out.
+
 
 # Home Assistant Configuration
 Once the DRS service is running, you need to configure Home Assistant to listen to the MQTT topics. Below you fill find examples for setups and automations.

--- a/config_template.py
+++ b/config_template.py
@@ -8,3 +8,11 @@ CACHE_FILENAME = 'cache.txt'
 # the MQTT Broker. This is because messages are received 
 # x - seconds before you see them on the broadcast.
 PUBLISH_DELAY = 54
+
+
+# Used to determine if and how often DRS will save a session cache
+# This is used in case the service crashes or fails and a restart
+# is required. This will hopefully still keep the latest result of 
+# interest.
+SESSION_CACHING_ENABLED = True
+SESSION_CACHING_INTERVAL = 10

--- a/config_template.py
+++ b/config_template.py
@@ -1,0 +1,10 @@
+"""Config File that holds across service Variables"""
+
+# The cache text file that the FastF1 livetiming service
+# Will write to, and the DRS will listen to.
+CACHE_FILENAME = 'cache.txt'
+
+# The delay between message received and even published to
+# the MQTT Broker. This is because messages are received 
+# x - seconds before you see them on the broadcast.
+PUBLISH_DELAY = 54

--- a/data/drs_data.json
+++ b/data/drs_data.json
@@ -1,146 +1,186 @@
 {
-    "teams" : {
-        "red_bull" : {
-            "name" : "Red Bull",
-            "driver_numbers" : ["1", "22"]
+    "teams": {
+        "red_bull": {
+            "name": "Red Bull",
+            "driver_numbers": [
+                "1",
+                "22"
+            ],
+            "color_hex": "4781D7"
         },
-        "ferrari" : {
-            "name" : "Ferrari",
-            "driver_numbers" : ["16", "44"]
+        "ferrari": {
+            "name": "Ferrari",
+            "driver_numbers": [
+                "16",
+                "44"
+            ],
+            "color_hex": "ED1131"
         },
-        "mercedes" : {
-            "name" : "Mercedes",
-            "driver_numbers" : ["12", "63"]
+        "mercedes": {
+            "name": "Mercedes",
+            "driver_numbers": [
+                "12",
+                "63"
+            ],
+            "color_hex": "00D7B6"
         },
-        "mclaren" : {
-            "name" : "McLaren",
-            "driver_numbers" : ["4", "81"]
+        "mclaren": {
+            "name": "McLaren",
+            "driver_numbers": [
+                "4",
+                "81"
+            ],
+            "color_hex": "F47600"
         },
-        "aston_martin" : {
-            "name" : "Aston Martin",
-            "driver_numbers" : ["14", "18"]
+        "aston_martin": {
+            "name": "Aston Martin",
+            "driver_numbers": [
+                "14",
+                "18"
+            ],
+            "color_hex": "229971"
         },
-        "alpine" : {
-            "name" : "Alpine",
-            "driver_numbers" : ["10", "43"]
+        "alpine": {
+            "name": "Alpine",
+            "driver_numbers": [
+                "10",
+                "43"
+            ],
+            "color_hex": "00A1E8"
         },
-        "racing_bulls" : {
-            "name" : "RB",
-            "driver_numbers" : ["6", "30"]
+        "racing_bulls": {
+            "name": "RB",
+            "driver_numbers": [
+                "6",
+                "30"
+            ],
+            "color_hex": "6C98FF"
         },
-        "haas" : {
-            "name" : "HAAS",
-            "driver_numbers" : ["31", "87"]
+        "haas": {
+            "name": "HAAS",
+            "driver_numbers": [
+                "31",
+                "87"
+            ],
+            "color_hex": "9C9FA2"
         },
-        "sauber" : {
-            "name" : "Sauber",
-            "driver_numbers" : ["5", "27"]
+        "sauber": {
+            "name": "Sauber",
+            "driver_numbers": [
+                "5",
+                "27"
+            ],
+            "color_hex": "01C00E"
         },
-        "williams" : {
-            "name" : "Williams",
-            "driver_numbers" : ["23", "55"]
+        "williams": {
+            "name": "Williams",
+            "driver_numbers": [
+                "23",
+                "55"
+            ],
+            "color_hex": "1868DB"
         }
     },
-    "drivers" : {
-        "1" : {
-            "name" : "Max Verstappen",
-            "abbreviation" : "VER",
-            "team_key" : "red_bull"
+    "drivers": {
+        "1": {
+            "name": "Max Verstappen",
+            "abbreviation": "VER",
+            "team_key": "red_bull"
         },
-        "22" : {
-            "name" : "Yuki Tsunoda",
-            "abbreviation" : "TSU",
-            "team_key" : "red_bull"
+        "22": {
+            "name": "Yuki Tsunoda",
+            "abbreviation": "TSU",
+            "team_key": "red_bull"
         },
-        "16" : {
-            "name" : "Charles Leclerc",
-            "abbreviation" : "LEC",
-            "team_key" : "ferrari"
+        "16": {
+            "name": "Charles Leclerc",
+            "abbreviation": "LEC",
+            "team_key": "ferrari"
         },
-        "44" : {
-            "name" : "Lewis Hamilton",
-            "abbreviation" : "LEW",
-            "team_key" : "ferrari"
+        "44": {
+            "name": "Lewis Hamilton",
+            "abbreviation": "LEW",
+            "team_key": "ferrari"
         },
-        "12" : {
-            "name" : "Kimi Antonelli",
-            "abbreviation" : "ANT",
-            "team_key" : "mercedes"
+        "12": {
+            "name": "Kimi Antonelli",
+            "abbreviation": "ANT",
+            "team_key": "mercedes"
         },
-        "63" : {
-            "name" : "George Russell",
-            "abbreviation" : "RUS",
-            "team_key" : "mercedes"
+        "63": {
+            "name": "George Russell",
+            "abbreviation": "RUS",
+            "team_key": "mercedes"
         },
-        "4" : {
-            "name" : "Lando Norris",
-            "abbreviation" : "NOR",
-            "team_key" : "mclaren"
+        "4": {
+            "name": "Lando Norris",
+            "abbreviation": "NOR",
+            "team_key": "mclaren"
         },
-        "81" : {
-            "name" : "Oscar Piastri",
-            "abbreviation" : "PIA",
-            "team_key" : "mclaren"
+        "81": {
+            "name": "Oscar Piastri",
+            "abbreviation": "PIA",
+            "team_key": "mclaren"
         },
-        "14" : {
-            "name" : "Fernando Alonso",
-            "abbreviation" : "ALO",
-            "team_key" : "aston_martin"
+        "14": {
+            "name": "Fernando Alonso",
+            "abbreviation": "ALO",
+            "team_key": "aston_martin"
         },
-        "18" : {
-            "name" : "Lance Stroll",
-            "abbreviation" : "STR",
-            "team_key" : "aston_martin"
+        "18": {
+            "name": "Lance Stroll",
+            "abbreviation": "STR",
+            "team_key": "aston_martin"
         },
-        "10" : {
-            "name" : "Pierre Gasly",
-            "abbreviation" : "GAS",
-            "team_key" : "alpine"
+        "10": {
+            "name": "Pierre Gasly",
+            "abbreviation": "GAS",
+            "team_key": "alpine"
         },
-        "43" : {
-            "name" : "Franco Colapinto",
-            "abbreviation" : "COL",
-            "team_key" : "alpine"
+        "43": {
+            "name": "Franco Colapinto",
+            "abbreviation": "COL",
+            "team_key": "alpine"
         },
-        "6" : {
-            "name" : "Isack Hadjar",
-            "abbreviation" : "HAD",
-            "team_key" : "racing_bulls"
+        "6": {
+            "name": "Isack Hadjar",
+            "abbreviation": "HAD",
+            "team_key": "racing_bulls"
         },
-        "30" : {
-            "name" : "Liam Lawson",
-            "abbreviation" : "LAW",
-            "team_key" : "racing_bulls"
+        "30": {
+            "name": "Liam Lawson",
+            "abbreviation": "LAW",
+            "team_key": "racing_bulls"
         },
-        "31" : {
-            "name" : "Estaban Ocon",
-            "abbreviation" : "OCO",
-            "team_key" : "haas"
+        "31": {
+            "name": "Estaban Ocon",
+            "abbreviation": "OCO",
+            "team_key": "haas"
         },
-        "87" : {
-            "name" : "Oliver Bearman",
-            "abbreviation" : "BEA",
-            "team_key" : "haas"
+        "87": {
+            "name": "Oliver Bearman",
+            "abbreviation": "BEA",
+            "team_key": "haas"
         },
-        "5" : {
-            "name" : "Gabriel Bortoleto",
-            "abbreviation" : "BOR",
-            "team_key" : "sauber"
+        "5": {
+            "name": "Gabriel Bortoleto",
+            "abbreviation": "BOR",
+            "team_key": "sauber"
         },
-        "27" : {
-            "name" : "Nico Hulkenberg",
-            "abbreviation" : "HUL",
-            "team_key" : "sauber"
+        "27": {
+            "name": "Nico Hulkenberg",
+            "abbreviation": "HUL",
+            "team_key": "sauber"
         },
-        "55" : {
-            "name" : "Carlos Sainz",
-            "abbreviation" : "SAI",
-            "team_key" : "williams"
+        "55": {
+            "name": "Carlos Sainz",
+            "abbreviation": "SAI",
+            "team_key": "williams"
         },
-        "23" : {
-            "name" : "Alexander Albon",
-            "abbreviation" : "ALB",
-            "team_key" : "williams"
+        "23": {
+            "name": "Alexander Albon",
+            "abbreviation": "ALB",
+            "team_key": "williams"
         }
     }
 }

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Team Color to the MQTT message on leader
 - Template files for the configs
 
+### CHANGED
+- Moving business logic in `main.py` to dedicated functions
+
 ### REMOVED
 - `config.py` from being tracked in the git repo
 

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### ADDED
+- Team Color to drs_data
+- Team Color to the MQTT message on leader
+- Template files for the configs
+
+### REMOVED
+- `config.py` from being tracked in the git repo
+
 ## [0.6.2] - 2025-10-11
 
 ### FIXED

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Team Color to drs_data
 - Team Color to the MQTT message on leader
 - Template files for the configs
+- Session Caching
+- Added tests for `main.py`
 
 ### CHANGED
 - Moving business logic in `main.py` to dedicated functions

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [0.7.0] - 2025-10-18 (FREEDOM release)
+
 ### ADDED
 - Team Color to drs_data
 - Team Color to the MQTT message on leader
 - Template files for the configs
-- Session Caching
-- Added tests for `main.py`
+- Session Caching (#10)
+- Added tests for `main.py` and `session_state.py`
+- Deleted lap time debug line (not used yet)
 
 ### CHANGED
-- Moving business logic in `main.py` to dedicated functions
+- Moving business logic in `main.py` to dedicated functions (#16)
+- `--Force-Lead` (`-fl`) is now **required** to provide for Races (Austin SR T1 is a great example for why the service needs to know how to reset after a Safety Car)
 
 ### REMOVED
 - `config.py` from being tracked in the git repo

--- a/docs/debug_lines.md
+++ b/docs/debug_lines.md
@@ -11,6 +11,8 @@ Lines going from slowest to fastest:
 ['TimingData', {'Lines': {'55': {'NumberOfLaps': 3, 'Sectors': {'2': {'Value': '24.386'}}, 'Speeds': {'FL': {'Value': '250'}}, 'BestLapTime': {'Value': '1:28.552', 'Lap': 2}, 'LastLapTime': {'Value': '1:26.552', 'OverallFastest': True, 'PersonalFastest': True}}}}, '2025-07-05T10:38:19.212Z']
 ['TimingData', {'Lines': {'4': {'NumberOfLaps': 3, 'Sectors': {'2': {'Value': '24.386'}}, 'Speeds': {'FL': {'Value': '250'}}, 'BestLapTime': {'Value': '1:28.552', 'Lap': 2}, 'LastLapTime': {'Value': '1:25.552', 'OverallFastest': True, 'PersonalFastest': True}}}}, '2025-07-05T10:38:19.212Z']
 
+### Lap Time Deleted
+['RaceControlMessages', {'Messages': {'3': {'Utc': '2025-10-17T21:35:06', 'Category': 'Other', 'Message': 'CAR 5 (BOR) TIME 1:36.313 DELETED - TRACK LIMITS AT TURN 19 LAP 3 16:34:16'}}}, '2025-10-17T21:35:06.611Z']
 
 ## Race Lead Change (Race):
 Race change messages, does not matter in what order you test them.

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from src.drs.mqtt_handler import MQTTHandler
 from src.drs.mqtt_topics import MqttTopics
 import src.drs.session_caching as session_caching
 
-DRS_VERSION = "0.6.3 ALPHA"
+DRS_VERSION = "0.7.0"
 
 SESSION_MAP = {
     'p' : 'practice',
@@ -61,8 +61,15 @@ def load_drs_data(filename : str = "drs_data.json") -> dict:
         logging.error(f"Could not decode JSON from {data_path}. Check for syntax errors: {e}")
         return {}
     
-def setup(args) -> tuple[SessionState, MQTTHandler, queue.Queue]:
+def setup(session_type: str) -> tuple[SessionState, MQTTHandler, queue.Queue]:
     """Handles all initial setup and object creation."""
+    normalized_session = SESSION_MAP.get(session_type.lower())
+
+    if not normalized_session:
+        logging.error(f"Error: Invalid session type '{session_type}'.")
+        logging.error(f"Valid options are: {', '.join(SESSION_MAP.keys())}")
+        exit(1)
+
     drs_data = load_drs_data()
     if not drs_data:
         logging.error("Could not load DRS data. Exiting.")
@@ -138,11 +145,13 @@ def main_loop(session_state:SessionState, mqtt: MQTTHandler, command_queue: queu
 
 def apply_forced_lead(session_state: SessionState, mqtt: MQTTHandler, team_key: str | None):
     """Force sets the lead on start if one is provided"""
-    if not team_key: return
+    if not team_key: 
+        return
 
     logging.info(f"Setting initial leading team as {team_key}")
     try:
-        forced_lead_team = session_state.teams_data.get(team_key.lower(), None)
+        clean_team_key = team_key.strip().lower().replace(' ', '_')
+        forced_lead_team = session_state.teams_data.get(clean_team_key, None)
         if not forced_lead_team:
             logging.warning(f"Unable to find a team named {team_key}, skipping.")
             return
@@ -171,16 +180,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    normalized_session = SESSION_MAP.get(args.session_type.lower())
-
-    if not normalized_session:
-        logging.error(f"Error: Invalid session type '{args.session_type}'.")
-        logging.error(f"Valid options are: {', '.join(SESSION_MAP.keys())}")
-        exit(1)
-
-    args = parser.parse_args()
-
-    session_state, mqtt, command_queue = setup(args)
+    session_state, mqtt, command_queue = setup(args.session_type)
     resumed_state = session_caching.load_state()
 
     if resumed_state:
@@ -189,6 +189,16 @@ if __name__ == "__main__":
             session_state = resumed_state
 
     apply_forced_lead(session_state, mqtt, args.force_lead)
+
+    if session_state.session_type == 'race' and not session_state.current_session_lead.team:
+        logging.error("="*50)
+        logging.error("FATAL: Starting a 'race' session with no leader set.")
+        logging.error("Please provide the P1 team using the --force-lead (-fl) argument.")
+        logging.error('Example: python main.py -fl "Red Bull"')
+        logging.error("="*50)
+
+        mqtt.disconnect()
+        exit(1)
 
     try:
         main_loop(session_state, mqtt, command_queue)

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ import src.drs.f1_utils as f1_utils
 from src.drs.mqtt_handler import MQTTHandler
 from src.drs.mqtt_topics import MqttTopics
 
-DRS_VERSION = "0.6.1"
+DRS_VERSION = "0.6.3 ALPHA"
 
 SESSION_MAP = {
     'p' : 'practice',
@@ -30,6 +30,8 @@ SESSION_MAP = {
     }
 
 
+
+# Parser
 parser = argparse.ArgumentParser(description="F1 Dahsboard Reaction Service")
 parser.add_argument(
     "session_type",
@@ -52,6 +54,8 @@ if not normalized_session:
     logging.error(f"Valid options are: {', '.join(SESSION_MAP.keys())}")
     exit(1)
 
+
+# Main logic
 def load_drs_data(filename : str = "drs_data.json") -> dict:
     """Loads the static F1 driver and team data from the JSON file"""
     data_path = Path(__file__).parent / "data" / filename
@@ -64,10 +68,9 @@ def load_drs_data(filename : str = "drs_data.json") -> dict:
     except json.JSONDecodeError as e:
         logging.error(f"Could not decode JSON from {data_path}. Check for syntax errors: {e}")
         return {}
-
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
+    
+def setup(args) -> tuple[SessionState, MQTTHandler, queue.Queue]:
+    """Handles all initial setup and object creation."""
     drs_data = load_drs_data()
     if not drs_data:
         logging.error("Could not load DRS data. Exiting.")
@@ -75,14 +78,9 @@ if __name__ == "__main__":
 
     session_state = SessionState(session_type=normalized_session, teams_data=drs_data.get("teams", {}), drivers_data=drs_data.get("drivers", {}))
 
-    if session_state.session_type == 'race':
-        race_lead_process = f1_utils.process_race_lead_line
-    else:
-        race_lead_process = f1_utils.process_lap_time_line
-
     command_queue = queue.Queue()
 
-    mqtt = MQTTHandler(
+    mqtt_handler = MQTTHandler(
         broker_ip=mqtt_config.MQTT_BROKER_IP,
         port=mqtt_config.MQTT_PORT,
         username=mqtt_config.MQTT_USERNAME,
@@ -91,55 +89,76 @@ if __name__ == "__main__":
         command_queue=command_queue,
     )
 
+    return session_state, mqtt_handler, command_queue
+
+def main_loop(session_state:SessionState, mqtt_handler: MQTTHandler, command_queue: queue.Queue):
+    """Main logic for parsing the watching the cache file"""
+    cache_file = config.CACHE_FILENAME
+
+    # Set how to discover the lead.
+    if session_state.session_type == 'race':
+        race_lead_process = f1_utils.process_race_lead_line
+    else:
+        race_lead_process = f1_utils.process_lap_time_line
+
+    with open(cache_file, 'r', encoding='utf-8', errors='replace') as f:
+        logging.info(f"DRS {DRS_VERSION} started {session_state.session_type} session. Reading live data from '{cache_file}'...")
+        f.seek(0, 2)
+        while True:
+        # Try block to look for user input delay from HA-
+            try:
+                command = command_queue.get_nowait()
+                if command == "CALIBRATE_START":
+
+                    # Ignore calibration after time limit as to avoid any "accidental presses"
+                    if session_state.true_session_start_time and (time.monotonic() - session_state.true_session_start_time) > 300:
+                        continue
+
+                    if session_state.true_session_start_time:
+                        new_delay = time.monotonic() - session_state.true_session_start_time
+                        mqtt.set_delay(new_delay)
+                        logging.info(f"received 'CALIBRATE_START' command from HA and set it to {new_delay}s")
+            except queue.Empty:
+                pass
+
+            line = f.readline()
+            if not line:
+                time.sleep(0.1)
+            else:
+                try:
+                    f1_utils.process_session_data_line(line, session_state, mqtt)
+                    race_lead_process(line, session_state, mqtt)
+                    f1_utils.process_race_control_line(line, session_state, mqtt)
+                except Exception as e:
+                    logging.error(f"Error processing line: {e}")
+
+            # Check if we're in qualifying, and that we're in-between sessions
+            if (session_state.session_type == 'qualifying' and 
+                session_state.cooldown_active and 
+                session_state.session_end_time and 
+                session_state.quali_session != 'Q3'):
+                if (time.monotonic() - session_state.session_end_time) > 180:
+                    logging.info("Resetting for next Qualifying session")
+                    session_state.reset_for_next_quali_segment()
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    args = parser.parse_args()
+
+    session_state, mqtt, command_queue = setup(args)
+
     if args.force_lead:
         logging.info(f"Setting initial leading team as {args.force_lead}")
-        session_state.set_session_lead(driver='FORCE', driver_number='0', team=args.force_lead)
-        forced_lead_payload = json.dumps({"driver": "FORCE", "drivcer_number": "0","team": args.force_lead})
-        mqtt.queue_message(MqttTopics.LEADER_TOPIC, forced_lead_payload, immediate=True)
+        try:
+            forced_lead_team = session_state.teams_data.get(args.force_lead.lower())
+            session_state.set_session_lead(driver='FORCE', driver_number='0', team=forced_lead_team.name)
+            forced_lead_payload = json.dumps({"driver": "FORCE", "drivcer_number": "0","team": forced_lead_team.name, "team_color": forced_lead_team.color_hex})
+            mqtt.queue_message(MqttTopics.LEADER_TOPIC, forced_lead_payload, immediate=True)
+        except Exception as e:
+            logging.warning(f"Was unable to force set leading team to {args.force_lead}. Error: {e}")
 
     try:
-        cache_file = config.CACHE_FILENAME
-        with open(cache_file, 'r', encoding='utf-8', errors='replace') as f:
-            logging.info(f"DRS {DRS_VERSION} started {session_state.session_type} session. Reading live data from '{cache_file}'...")
-            f.seek(0, 2)
-            while True:
-            # Try block to look for user input delay from HA-
-                try:
-                    command = command_queue.get_nowait()
-                    if command == "CALIBRATE_START":
-
-                        # Ignore calibration after time limit as to avoid any "accidental presses"
-                        if session_state.true_session_start_time and (time.monotonic() - session_state.true_session_start_time) > 300:
-                            continue
-
-                        if session_state.true_session_start_time:
-                            new_delay = time.monotonic() - session_state.true_session_start_time
-                            mqtt.set_delay(new_delay)
-                            logging.info(f"received 'CALIBRATE_START' command from HA and set it to {new_delay}s")
-                except queue.Empty:
-                    pass
-
-                line = f.readline()
-                if not line:
-                    time.sleep(0.1)
-                else:
-                    try:
-                        f1_utils.process_session_data_line(line, session_state, mqtt)
-                        race_lead_process(line, session_state, mqtt)
-                        f1_utils.process_race_control_line(line, session_state, mqtt)
-                    except Exception as e:
-                        logging.error(f"Error processing line: {e}")
-
-                # Check if we're in qualifying, and that we're in-between sessions
-                if (session_state.session_type == 'qualifying' and 
-                    session_state.cooldown_active and 
-                    session_state.session_end_time and 
-                    session_state.quali_session != 'Q3'):
-                    if (time.monotonic() - session_state.session_end_time) > 180:
-                        logging.info("Resetting for next Qualifying session")
-                        session_state.reset_for_next_quali_segment()
-    
-
+        main_loop(session_state, mqtt, command_queue)
     except KeyboardInterrupt:
         logging.info("Service stopped by user.")
     except FileNotFoundError:

--- a/main.py
+++ b/main.py
@@ -1,17 +1,18 @@
 import time
 import logging
 import argparse
-from datetime import timedelta, datetime
+import copy
 import json
 import queue
 from pathlib import Path
 
-import config
+from config import CACHE_FILENAME, PUBLISH_DELAY, SESSION_CACHING_ENABLED, SESSION_CACHING_INTERVAL
 import mqtt_config
 from src.drs.session_state import SessionState
 import src.drs.f1_utils as f1_utils
 from src.drs.mqtt_handler import MQTTHandler
 from src.drs.mqtt_topics import MqttTopics
+import src.drs.session_caching as session_caching
 
 DRS_VERSION = "0.6.3 ALPHA"
 
@@ -30,32 +31,23 @@ SESSION_MAP = {
     }
 
 
-
-# Parser
-parser = argparse.ArgumentParser(description="F1 Dahsboard Reaction Service")
-parser.add_argument(
-    "session_type",
-    help="The type of session to monitor: practice, free practice, qualifying, sprint qualifying, race, sprint race"
-)
-parser.add_argument(
-    '-fl', '--force-lead',
-    metavar='TEAM_NAME',
-    type=str,
-    default=None,
-    help="(Optional) Force an initial leader state on startup. E.g., --force-leader Ferrari",
-)
-
-args = parser.parse_args()
-
-normalized_session = SESSION_MAP.get(args.session_type.lower())
-
-if not normalized_session:
-    logging.error(f"Error: Invalid session type '{args.session_type}'.")
-    logging.error(f"Valid options are: {', '.join(SESSION_MAP.keys())}")
-    exit(1)
-
-
 # Main logic
+def handle_periodic_caching(current_state: SessionState, last_cached_state: SessionState, last_cached_time: float) -> tuple[SessionState, float]:
+    """Checks if the the state is dirty and caches it if it is"""
+    current_time = time.monotonic()
+
+    if (current_time - last_cached_time) > SESSION_CACHING_INTERVAL:
+
+        if current_state != last_cached_state:
+            session_caching.save_state(current_state)
+            last_cached_state = copy.deepcopy(current_state)
+            return copy.deepcopy(current_state), current_time
+        
+        return last_cached_state, current_time
+    
+    return last_cached_state, last_cached_time
+
+
 def load_drs_data(filename : str = "drs_data.json") -> dict:
     """Loads the static F1 driver and team data from the JSON file"""
     data_path = Path(__file__).parent / "data" / filename
@@ -85,15 +77,14 @@ def setup(args) -> tuple[SessionState, MQTTHandler, queue.Queue]:
         port=mqtt_config.MQTT_PORT,
         username=mqtt_config.MQTT_USERNAME,
         password=mqtt_config.MQTT_PASSWORD,
-        delay=config.PUBLISH_DELAY,
+        delay=PUBLISH_DELAY,
         command_queue=command_queue,
     )
 
     return session_state, mqtt_handler, command_queue
 
-def main_loop(session_state:SessionState, mqtt_handler: MQTTHandler, command_queue: queue.Queue):
+def main_loop(session_state:SessionState, mqtt: MQTTHandler, command_queue: queue.Queue):
     """Main logic for parsing the watching the cache file"""
-    cache_file = config.CACHE_FILENAME
 
     # Set how to discover the lead.
     if session_state.session_type == 'race':
@@ -101,8 +92,12 @@ def main_loop(session_state:SessionState, mqtt_handler: MQTTHandler, command_que
     else:
         race_lead_process = f1_utils.process_lap_time_line
 
-    with open(cache_file, 'r', encoding='utf-8', errors='replace') as f:
-        logging.info(f"DRS {DRS_VERSION} started {session_state.session_type} session. Reading live data from '{cache_file}'...")
+    last_cached_state = copy.deepcopy(session_state)
+    last_cache_time = time.monotonic()
+    
+
+    with open(CACHE_FILENAME, 'r', encoding='utf-8', errors='replace') as f:
+        logging.info(f"DRS {DRS_VERSION} started {session_state.session_type} session. Reading live data from '{CACHE_FILENAME}'...")
         f.seek(0, 2)
         while True:
         # Try block to look for user input delay from HA-
@@ -110,11 +105,7 @@ def main_loop(session_state:SessionState, mqtt_handler: MQTTHandler, command_que
                 command = command_queue.get_nowait()
                 if command == "CALIBRATE_START":
 
-                    # Ignore calibration after time limit as to avoid any "accidental presses"
-                    if session_state.true_session_start_time and (time.monotonic() - session_state.true_session_start_time) > 300:
-                        continue
-
-                    if session_state.true_session_start_time:
+                    if session_state.true_session_start_time and (time.monotonic() - session_state.true_session_start_time) < 300:
                         new_delay = time.monotonic() - session_state.true_session_start_time
                         mqtt.set_delay(new_delay)
                         logging.info(f"received 'CALIBRATE_START' command from HA and set it to {new_delay}s")
@@ -132,6 +123,10 @@ def main_loop(session_state:SessionState, mqtt_handler: MQTTHandler, command_que
                 except Exception as e:
                     logging.error(f"Error processing line: {e}")
 
+            # Check if we should try to cache
+            if SESSION_CACHING_ENABLED:
+                last_cached_state, last_cache_time = handle_periodic_caching(session_state, last_cached_state, last_cache_time)
+
             # Check if we're in qualifying, and that we're in-between sessions
             if (session_state.session_type == 'qualifying' and 
                 session_state.cooldown_active and 
@@ -141,30 +136,74 @@ def main_loop(session_state:SessionState, mqtt_handler: MQTTHandler, command_que
                     logging.info("Resetting for next Qualifying session")
                     session_state.reset_for_next_quali_segment()
 
+def apply_forced_lead(session_state: SessionState, mqtt: MQTTHandler, team_key: str | None):
+    """Force sets the lead on start if one is provided"""
+    if not team_key: return
+
+    logging.info(f"Setting initial leading team as {team_key}")
+    try:
+        forced_lead_team = session_state.teams_data.get(team_key.lower(), None)
+        if not forced_lead_team:
+            logging.warning(f"Unable to find a team named {team_key}, skipping.")
+            return
+        session_state.set_session_lead(driver='FORCE', driver_number='0', team=forced_lead_team['name'])
+        forced_lead_payload = json.dumps({"driver": "FORCE", "driver_number": "0","team": forced_lead_team['name'], "team_color": forced_lead_team.get('color_hex', 'FFFFFF')})
+        mqtt.queue_message(MqttTopics.LEADER_TOPIC, forced_lead_payload, immediate=True)
+    except Exception as e:
+        logging.warning(f"Was unable to force set leading team to {team_key}. Error: {e}")
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    # Parser
+    parser = argparse.ArgumentParser(description="F1 Dahsboard Reaction Service")
+    parser.add_argument(
+        "session_type",
+        help="The type of session to monitor: practice, free practice, qualifying, sprint qualifying, race, sprint race"
+    )
+    parser.add_argument(
+        '-fl', '--force-lead',
+        metavar='TEAM_NAME',
+        type=str,
+        default=None,
+        help="(Optional) Force an initial leader state on startup. E.g., --force-leader Ferrari",
+    )
+
+    args = parser.parse_args()
+
+    normalized_session = SESSION_MAP.get(args.session_type.lower())
+
+    if not normalized_session:
+        logging.error(f"Error: Invalid session type '{args.session_type}'.")
+        logging.error(f"Valid options are: {', '.join(SESSION_MAP.keys())}")
+        exit(1)
+
     args = parser.parse_args()
 
     session_state, mqtt, command_queue = setup(args)
+    resumed_state = session_caching.load_state()
 
-    if args.force_lead:
-        logging.info(f"Setting initial leading team as {args.force_lead}")
-        try:
-            forced_lead_team = session_state.teams_data.get(args.force_lead.lower())
-            session_state.set_session_lead(driver='FORCE', driver_number='0', team=forced_lead_team.name)
-            forced_lead_payload = json.dumps({"driver": "FORCE", "drivcer_number": "0","team": forced_lead_team.name, "team_color": forced_lead_team.color_hex})
-            mqtt.queue_message(MqttTopics.LEADER_TOPIC, forced_lead_payload, immediate=True)
-        except Exception as e:
-            logging.warning(f"Was unable to force set leading team to {args.force_lead}. Error: {e}")
+    if resumed_state:
+        use_prev_state = input(f"Found state cache, resume from this? (y/n:)").lower()
+        if use_prev_state == 'y':
+            session_state = resumed_state
+
+    apply_forced_lead(session_state, mqtt, args.force_lead)
 
     try:
         main_loop(session_state, mqtt, command_queue)
     except KeyboardInterrupt:
+        session_caching.save_state(session_state)
         logging.info("Service stopped by user.")
+        logging.shutdown()
+        retain_cache = input("Do you want to retain the session cache (do not keep if session is done)? (y/n): ").lower()
+        if retain_cache != 'y':
+            session_caching.delete_state_cache()
     except FileNotFoundError:
-        logging.error(f"[FATAL] Data file not found: {config.CACHE_FILENAME}")
+        logging.error(f"[FATAL] Data file not found: {CACHE_FILENAME}")
     except Exception as e:
         logging.error(f"An unexpected error occurred: {e}")
+        session_caching.save_state(session_state)
     finally:
         mqtt.disconnect()
         logging.info("MQTT client disconnected.")

--- a/mqtt_config_template.py
+++ b/mqtt_config_template.py
@@ -1,0 +1,4 @@
+MQTT_BROKER_IP = "0.0.0.0" 
+MQTT_PORT = 1883 # For unsecure communication running over local network
+MQTT_USERNAME = "service_user_name"
+MQTT_PASSWORD = "your_strong_password" # MQTT password that's also present in your Home Assistant

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,6 +25,7 @@ Pygments==2.19.2
 pyparsing==3.2.3
 pytest==8.4.2
 pytest-freezegun==0.4.2
+pytest-mock==3.15.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 RapidFuzz==3.13.0

--- a/src/drs/f1_utils.py
+++ b/src/drs/f1_utils.py
@@ -71,12 +71,15 @@ def process_race_lead_line(line: str, state: SessionState, mqtt_handler: MQTTHan
                 team_key = driver_info['team_key']
 
                 team_name = state.teams_data[team_key]['name']
+                team_color = state.teams_data[team_key]['color_hex']
             except KeyError:
                 logging.warning(f"Could not find driver or team for {new_leader_num}")
                 driver_abbreviation = "UNK"
                 team_name = "UNKNOWN"
+                team_color = None
             state.set_session_lead(driver=driver_abbreviation, driver_number=new_leader_num, team=team_name)
-            payload = json.dumps({"driver": driver_abbreviation, "driver_number": new_leader_num, "team": team_name})
+            payload = json.dumps({"driver": driver_abbreviation, "driver_number": new_leader_num, "team": team_name, "team_color": team_color})
+
             mqtt_handler.queue_message(MqttTopics.LEADER_TOPIC, payload)
 
 def process_race_control_line(line: str, state: SessionState, mqtt_handler: MQTTHandler) -> None:

--- a/src/drs/f1_utils.py
+++ b/src/drs/f1_utils.py
@@ -49,13 +49,15 @@ def process_lap_time_line(line: str, state: SessionState, mqtt_handler: MQTTHand
                         driver_abbreviation = driver_info['abbreviation']
                         team_key = driver_info['team_key']
                         team_name = state.teams_data[team_key]['name']
+                        team_color = state.teams_data[team_key]['color_hex']
                     except KeyError:
                         logging.warning(f"Could not find driver or team for {num}, setting unknown")
                         driver_abbreviation = "UNK"
                         team_name = "UNKNOWN"
+                        team_color = None
                     state.set_fastest_lap(lap_time, driver_abbreviation, team_name)
                     state.set_session_lead(driver=driver_abbreviation, driver_number=num, team=team_name)
-                    payload = json.dumps({"driver": driver_abbreviation, "driver_number": num, "team": team_name})
+                    payload = json.dumps({"driver": driver_abbreviation, "driver_number": num, "team": team_name, "team_color": team_color})
                     mqtt_handler.queue_message(MqttTopics.LEADER_TOPIC, payload)
 
 def process_race_lead_line(line: str, state: SessionState, mqtt_handler: MQTTHandler) -> None:

--- a/src/drs/session_caching.py
+++ b/src/drs/session_caching.py
@@ -1,0 +1,37 @@
+import pickle
+import logging
+from pathlib import Path
+from typing import Optional
+
+from .session_state import SessionState
+
+SESSION_CACHE_FILE = Path('session_cache.pkl')
+
+def save_state(state: SessionState):
+    """Serializes and saves the SessionState object to a file"""
+    try:
+        with open(SESSION_CACHE_FILE, 'wb') as f:
+            pickle.dump(state, f)
+    except Exception as e:
+        logging.error(f"Failed to save session state: {e}")
+
+def delete_state_cache():
+    """Deletes the session cache file"""
+    if SESSION_CACHE_FILE.exists():
+        try:
+            SESSION_CACHE_FILE.unlink()
+        except Exception as e:
+            logging.error(f"Failed to delete session state cache: {e}")
+
+
+def load_state() -> Optional[SessionState]:
+    """Loads and deserializes a SessionState object from a file if it exists."""
+    if not SESSION_CACHE_FILE.exists():
+        return None
+    try:
+        with open(SESSION_CACHE_FILE, 'rb') as f:
+            state = pickle.load(f)
+            return state
+    except Exception as e:
+        logging.error(f"Failed to load session state: {e}")
+        return None            

--- a/tests/test_f1_utils.py
+++ b/tests/test_f1_utils.py
@@ -145,7 +145,7 @@ class TestProcessLapTimeLine:
         assert state.fastest_lap_info.time > fast_lap_time
 
 ## Yellow Flag and Clear
-def test_yellow_flag_and_clear_scenario(state: SessionState, mock_mqtt: Mock):
+def test_yellow_flag_from_green(state: SessionState, mock_mqtt: Mock):
     """Testing when yellow flags are raised and then cleared"""
     # Set yellow flag in sector 2
     yellow_flag_line = "['RaceControlMessages', {'Messages': {'56': {'Utc': '2025-07-05T11:39:56', 'Category': 'Flag', 'Flag': 'YELLOW', 'Scope': 'Sector', 'Sector': 2, 'Message': 'YELLOW IN TRACK SECTOR 2'}}}, '2025-07-05T11:39:56.262Z']"
@@ -155,15 +155,59 @@ def test_yellow_flag_and_clear_scenario(state: SessionState, mock_mqtt: Mock):
     # Assert
     ## States
     assert state.race_state == 'YELLOW'
-    assert 2 in state.yellow_flags
+    assert state.yellow_flags == {2}
 
     ## MQTT
     mock_mqtt.queue_message.assert_called_once()
     expected_payload = json.dumps({"flag": "YELLOW", "message": "YELLOW IN TRACK SECTOR 2"})
     mock_mqtt.queue_message.assert_called_with(MqttTopics.FLAG_TOPIC, expected_payload)
 
+# Need a test to add one more sector
+def test_yellow_flag_while_in_yellow(state: SessionState, mock_mqtt: Mock):
+    """Testing adding a new yellow flag to sector"""
+    # Setup
+    state.set_race_state('YELLOW')
+    state.add_sector_to_yellow_flags(2)
+
+    # Set yellow flag in Sector 3
+    yellow_flag_line = "['RaceControlMessages', {'Messages': {'56': {'Utc': '2025-07-05T11:39:56', 'Category': 'Flag', 'Flag': 'YELLOW', 'Scope': 'Sector', 'Sector': 3, 'Message': 'YELLOW IN TRACK SECTOR 3'}}}, '2025-07-05T11:39:56.262Z']"
+
+    process_race_control_line(yellow_flag_line, state, mock_mqtt)
+
+    # ASSERT
+    assert state.race_state == 'YELLOW'
+    assert state.yellow_flags == {2, 3}
+
+    mock_mqtt.queue_message.assert_not_called() # No new MQTT should be sent
+
+def test_yellow_flag_cleared_stay_in_yello(state: SessionState, mock_mqtt: Mock):
+    """Testing that a flag can be removed, but we remain in yellow"""
+    # Setup
+    state.set_race_state('YELLOW')
+    state.add_sector_to_yellow_flags(2)
+    state.add_sector_to_yellow_flags(3)
+
     # Clear yellow flag
-    clear_flag_line = "['RaceControlMessages', {'Messages': {'13': {'Utc': '2025-09-06T14:22:44', 'Category': 'Flag', 'Flag': 'CLEAR', 'Scope': 'Sector', 'Sector': 2, 'Message': 'CLEAR IN TRACK SECTOR 8'}}}, '2025-09-06T14:22:43.772Z']"
+    clear_flag_line = "['RaceControlMessages', {'Messages': {'13': {'Utc': '2025-09-06T14:22:44', 'Category': 'Flag', 'Flag': 'CLEAR', 'Scope': 'Sector', 'Sector': 3, 'Message': 'CLEAR IN TRACK SECTOR 3'}}}, '2025-09-06T14:22:43.772Z']"
+    process_race_control_line(clear_flag_line, state, mock_mqtt)
+
+    # ASSERT
+    assert state.race_state == 'YELLOW'
+    assert state.yellow_flags == {2}
+
+    mock_mqtt.queue_message.assert_not_called() # No new MQTT should be sent
+
+
+# Need a test that removes one sector, but remain in yellow
+
+def test_yellow_flag_clear_back_to_green(state: SessionState, mock_mqtt: Mock):
+    """Testing that yellow flags are cleared and we go back to green conditions"""
+    # Setup
+    state.add_sector_to_yellow_flags(2)
+    state.set_race_state('YELLOW')
+
+    # Clear yellow flag
+    clear_flag_line = "['RaceControlMessages', {'Messages': {'13': {'Utc': '2025-09-06T14:22:44', 'Category': 'Flag', 'Flag': 'CLEAR', 'Scope': 'Sector', 'Sector': 2, 'Message': 'CLEAR IN TRACK SECTOR 2'}}}, '2025-09-06T14:22:43.772Z']"
     process_race_control_line(clear_flag_line, state, mock_mqtt)
 
     # ASSERT
@@ -172,7 +216,7 @@ def test_yellow_flag_and_clear_scenario(state: SessionState, mock_mqtt: Mock):
     assert len(state.yellow_flags) == 0
 
     ## MQTT
-    assert mock_mqtt.queue_message.call_count == 2
+    mock_mqtt.queue_message.assert_called_once()
     expected_payload = json.dumps({"flag": "GREEN", "message": "GREEN FLAG, ALL YELLOW CLEARED"})
     mock_mqtt.queue_message.assert_called_with(MqttTopics.FLAG_TOPIC, expected_payload)
 
@@ -190,6 +234,20 @@ def test_safety_car_deployed_scenario(state: SessionState, mock_mqtt: Mock):
     mock_mqtt.queue_message.assert_called_once()
     expected_payload = json.dumps({"flag": "SAFETY CAR", "message": "SAFETY CAR"})
     mock_mqtt.queue_message.assert_called_with(MqttTopics.FLAG_TOPIC, expected_payload)
+
+def test_safety_car_deployed_while_in_yellow_scenario(state: SessionState, mock_mqtt: Mock):
+    """Testing full safety car deployment while under yellow flag condition"""
+    # Setup
+    state.set_race_state('YELLOW')
+    state.add_sector_to_yellow_flags(2)
+
+    safety_car_line = "['RaceControlMessages', {'Messages': {'97': {'Utc': '2025-07-06T14:29:14', 'Lap': 14, 'Category': 'SafetyCar', 'Status': 'DEPLOYED', 'Mode': 'SAFETY CAR', 'Message': 'SAFETY CAR DEPLOYED'}}}, '2025-07-06T14:29:14.267Z']"
+    
+    process_race_control_line(safety_car_line, state, mock_mqtt)
+
+    # Asserting
+    assert state.race_state == 'SAFETY CAR'
+    assert state.yellow_flags == set()
     
 # Testing Full safety car In This Lap
 def test_safety_car_in_scenario(state: SessionState, mock_mqtt: Mock):
@@ -222,6 +280,20 @@ def test_vsc_deployed_scenario(state: SessionState, mock_mqtt: Mock):
     expected_payload = json.dumps({"flag": "SAFETY CAR", "message": "VIRTUAL SAFETY CAR"})
     mock_mqtt.queue_message.assert_called_with(MqttTopics.FLAG_TOPIC, expected_payload)
 
+# Testing Virtual Safety Car Deployed
+def test_vsc_deployed_while_in_yellow_scenario(state: SessionState, mock_mqtt: Mock):
+    """Testing virtual safety car deployment while in yellow"""
+    # Setup
+    vsc_line = "['RaceControlMessages', {'Messages': {'67': {'Utc': '2025-07-06T14:05:48', 'Lap': 2, 'Category': 'SafetyCar', 'Status': 'DEPLOYED', 'Mode': 'VIRTUAL SAFETY CAR', 'Message': 'VIRTUAL SAFETY CAR DEPLOYED'}}}, '2025-07-06T14:05:47.647Z']"
+    state.set_race_state('YELLOW')
+    state.add_sector_to_yellow_flags(2)
+
+    process_race_control_line(vsc_line, state, mock_mqtt)
+
+    # Asserting
+    assert state.race_state == 'SAFETY CAR'
+    assert state.yellow_flags == set()   
+
 # Testing Virtual Safety Car Ending
 def test_vsc_ending_scenario(state:SessionState, mock_mqtt: Mock):
     """Testing full safety car in this lap"""
@@ -240,7 +312,7 @@ def test_vsc_ending_scenario(state:SessionState, mock_mqtt: Mock):
 
 # Test Red Flag
 def test_red_flag_scenario(state: SessionState, mock_mqtt: Mock):
-    """Testing when red flags are raised and then cleared"""
+    """Testing when red flags are raised"""
     # Set red flag
     red_flag_line = "['RaceControlMessages', {'Messages': {'50': {'Utc': '2025-07-05T11:33:58', 'Category': 'Flag', 'Flag': 'RED', 'Scope': 'Track', 'Message': 'RED FLAG'}}}, '2025-07-05T11:33:58.102Z']"
     process_race_control_line(red_flag_line, state, mock_mqtt)
@@ -252,6 +324,21 @@ def test_red_flag_scenario(state: SessionState, mock_mqtt: Mock):
     mock_mqtt.queue_message.assert_called_once()
     expected_payload = json.dumps({"flag": "RED", "message": "RED FLAG"})
     mock_mqtt.queue_message.assert_called_with(MqttTopics.FLAG_TOPIC, expected_payload)
+
+def test_red_flag_from_yellow_scenario(state: SessionState, mock_mqtt: Mock):
+    """Testing when red flags are raised while in a yellow flag scenario"""
+    # Setup
+    state.set_race_state('YELLOW')
+    state.add_sector_to_yellow_flags(2)
+
+    # Set red flag
+    red_flag_line = "['RaceControlMessages', {'Messages': {'50': {'Utc': '2025-07-05T11:33:58', 'Category': 'Flag', 'Flag': 'RED', 'Scope': 'Track', 'Message': 'RED FLAG'}}}, '2025-07-05T11:33:58.102Z']"
+    process_race_control_line(red_flag_line, state, mock_mqtt)
+
+    # Assert
+    ## States
+    assert state.race_state == 'RED'
+    assert state.yellow_flags == set()   
     
 def test_red_flag_ending_scenario(state: SessionState, mock_mqtt: Mock):
     """Testing that end of Red flag and back to Green conditions"""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,80 @@
+import dataclasses
+import pytest
+from freezegun import freeze_time
+from unittest.mock import Mock, MagicMock
+import json
+from datetime import timedelta
+import time
+
+from main import apply_forced_lead
+from src.drs.mqtt_topics import MqttTopics
+from src.drs.session_state import SessionState
+
+# --- Fixtures ---
+
+MOCK_DRS_DATA = {
+    "drivers": {
+        "1" : {'abbreviation' : 'VER', 'team_key' : 'red_bull'},
+        "10" : {'abbreviation' : 'GAS', 'team_key' : 'alpine'},
+        "16" : {'abbreviation' : 'LEC', 'team_key' : 'ferrari'},
+        "55" : {'abbreviation' : 'SAI', 'team_key' : 'williams'}
+    },
+    "teams" : {
+        'red_bull' : {'name' : 'Red Bull', "color_hex": "4781D7"},
+        'ferrari' : {'name' : 'Ferrari', "color_hex": "ED1131"},
+        'alpine' : {'name' : 'Alpine', "color_hex": "00A1E8"},
+        'williams' : {'name' : 'Williams', "color_hex": "1868DB"}
+    }
+}
+
+@pytest.fixture
+def state():
+    """Provides a fresh state dict"""
+    return SessionState(session_type='race', drivers_data=MOCK_DRS_DATA["drivers"], teams_data=MOCK_DRS_DATA["teams"])
+
+@pytest.fixture
+def mock_mqtt():
+    """Provides a fresh mock MQTT handler"""
+    return Mock()
+
+# --- Tests ---
+
+def test_force_team_lead_valid(state:SessionState, mock_mqtt: Mock):
+
+    apply_forced_lead(state, mock_mqtt, 'alpine')
+    assert state.current_session_lead.driver == 'FORCE'
+    assert state.current_session_lead.driver_number == '0'
+    assert state.current_session_lead.team == 'Alpine'
+
+    mock_mqtt.queue_message.assert_called_once()
+    expected_payload = json.dumps({"driver": "FORCE", "driver_number" : "0", "team": "Alpine", "team_color": "00A1E8"})
+    mock_mqtt.queue_message.assert_called_with(MqttTopics.LEADER_TOPIC, expected_payload, immediate=True)
+
+def test_force_team_lead_valid_random_capitalized(state:SessionState, mock_mqtt: Mock):
+
+    apply_forced_lead(state, mock_mqtt, 'aLpINe')
+    assert state.current_session_lead.driver == 'FORCE'
+    assert state.current_session_lead.driver_number == '0'
+    assert state.current_session_lead.team == 'Alpine'
+
+    mock_mqtt.queue_message.assert_called_once()
+    expected_payload = json.dumps({"driver": "FORCE", "driver_number" : "0", "team": "Alpine", "team_color": "00A1E8"})
+    mock_mqtt.queue_message.assert_called_with(MqttTopics.LEADER_TOPIC, expected_payload, immediate=True)
+
+def test_force_team_lead_invalid(state:SessionState, mock_mqtt: Mock):
+    
+    apply_forced_lead(state, mock_mqtt, 'frarari')
+    assert state.current_session_lead.driver == None
+    assert state.current_session_lead.driver_number == None
+    assert state.current_session_lead.team == None
+
+    mock_mqtt.queue_message.assert_not_called()
+
+def test_force_team_lead_empty(state:SessionState, mock_mqtt: Mock):
+    
+    apply_forced_lead(state, mock_mqtt, '')
+    assert state.current_session_lead.driver == None
+    assert state.current_session_lead.driver_number == None
+    assert state.current_session_lead.team == None
+
+    mock_mqtt.queue_message.assert_not_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,7 @@ import json
 from datetime import timedelta
 import time
 
-from main import apply_forced_lead
+from main import apply_forced_lead, setup, SESSION_MAP
 from src.drs.mqtt_topics import MqttTopics
 from src.drs.session_state import SessionState
 
@@ -39,8 +39,9 @@ def mock_mqtt():
 
 # --- Tests ---
 
+## FORCE TEAM LEAD
 def test_force_team_lead_valid(state:SessionState, mock_mqtt: Mock):
-
+    """Test that Force Team Lead is set correctly"""
     apply_forced_lead(state, mock_mqtt, 'alpine')
     assert state.current_session_lead.driver == 'FORCE'
     assert state.current_session_lead.driver_number == '0'
@@ -51,7 +52,7 @@ def test_force_team_lead_valid(state:SessionState, mock_mqtt: Mock):
     mock_mqtt.queue_message.assert_called_with(MqttTopics.LEADER_TOPIC, expected_payload, immediate=True)
 
 def test_force_team_lead_valid_random_capitalized(state:SessionState, mock_mqtt: Mock):
-
+    """Test that Force Team Lead is set correctly even with random capitalization"""
     apply_forced_lead(state, mock_mqtt, 'aLpINe')
     assert state.current_session_lead.driver == 'FORCE'
     assert state.current_session_lead.driver_number == '0'
@@ -61,8 +62,19 @@ def test_force_team_lead_valid_random_capitalized(state:SessionState, mock_mqtt:
     expected_payload = json.dumps({"driver": "FORCE", "driver_number" : "0", "team": "Alpine", "team_color": "00A1E8"})
     mock_mqtt.queue_message.assert_called_with(MqttTopics.LEADER_TOPIC, expected_payload, immediate=True)
 
+def test_force_team_lead_valid_with_spaced_name(state: SessionState, mock_mqtt: Mock):
+    """Tests that Force Team Lead is set correctly even if the team name is used with space"""
+    apply_forced_lead(state, mock_mqtt, '  Red Bull ')
+    assert state.current_session_lead.driver == 'FORCE'
+    assert state.current_session_lead.driver_number == '0'
+    assert state.current_session_lead.team == 'Red Bull'
+
+    mock_mqtt.queue_message.assert_called_once()
+    expected_payload = json.dumps({"driver": "FORCE", "driver_number" : "0", "team": "Red Bull", "team_color": "4781D7"})
+    mock_mqtt.queue_message.assert_called_with(MqttTopics.LEADER_TOPIC, expected_payload, immediate=True)
+
 def test_force_team_lead_invalid(state:SessionState, mock_mqtt: Mock):
-    
+    """Test that Force Team Lead is not set with unknown team input"""
     apply_forced_lead(state, mock_mqtt, 'frarari')
     assert state.current_session_lead.driver == None
     assert state.current_session_lead.driver_number == None
@@ -71,10 +83,39 @@ def test_force_team_lead_invalid(state:SessionState, mock_mqtt: Mock):
     mock_mqtt.queue_message.assert_not_called()
 
 def test_force_team_lead_empty(state:SessionState, mock_mqtt: Mock):
-    
+    """Test that Force Team Lead is not set with empty input"""
     apply_forced_lead(state, mock_mqtt, '')
     assert state.current_session_lead.driver == None
     assert state.current_session_lead.driver_number == None
     assert state.current_session_lead.team == None
 
     mock_mqtt.queue_message.assert_not_called()
+
+## SETUP
+test_session_cases = list(SESSION_MAP.items())
+@pytest.mark.parametrize("session_input, expected_session", test_session_cases)
+def test_setup_valid_session_types(mocker, session_input, expected_session):
+    """Tests that state is set to race from args"""
+    mocker.patch('main.MQTTHandler')
+    mocker.patch('main.load_drs_data', return_value={"teams": {}, "drivers": {}})
+
+    state, _, _ = setup(session_input)
+
+    assert state.session_type == expected_session
+    
+def test_setup_valid_session_random_capitalization(mocker):
+    """Tests that setup will run correctly and state is set correctly with random capitalization"""
+    mocker.patch('main.MQTTHandler')
+    mocker.patch('main.load_drs_data', return_value={"teams": {}, "drivers": {}})
+
+    state, _, _ = setup("SprINT rAcE")
+    assert state.session_type == "race"
+    
+def test_setup_invalid_session_types(mocker):
+    """Tests that setup fails on invalid session type"""
+    mocker.patch('main.MQTTHandler')
+    mocker.patch('main.load_drs_data', return_value={"teams": {}, "drivers": {}})
+
+    with pytest.raises(SystemExit):
+        setup("indy_car_session")
+

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,0 +1,148 @@
+import dataclasses
+import pytest
+from freezegun import freeze_time
+from unittest.mock import Mock, MagicMock
+import json
+from datetime import timedelta
+import time
+
+from src.drs.session_state import SessionState
+
+# --- Fixtures ---
+
+MOCK_DRS_DATA = {
+    "drivers": {
+        "1" : {'abbreviation' : 'VER', 'team_key' : 'red_bull'},
+        "10" : {'abbreviation' : 'GAS', 'team_key' : 'alpine'},
+        "16" : {'abbreviation' : 'LEC', 'team_key' : 'ferrari'},
+        "55" : {'abbreviation' : 'SAI', 'team_key' : 'williams'}
+    },
+    "teams" : {
+        'red_bull' : {'name' : 'Red Bull', "color_hex": "4781D7"},
+        'ferrari' : {'name' : 'Ferrari', "color_hex": "ED1131"},
+        'alpine' : {'name' : 'Alpine', "color_hex": "00A1E8"},
+        'williams' : {'name' : 'Williams', "color_hex": "1868DB"}
+    }
+}
+
+@pytest.fixture
+def state():
+    """Provides a fresh state dict"""
+    return SessionState(session_type='race', drivers_data=MOCK_DRS_DATA["drivers"], teams_data=MOCK_DRS_DATA["teams"])
+
+# --- Tests ---
+def test_set_race_state(state: SessionState):
+    """Tests setting the race state"""
+    state.set_race_state('YELLOW')
+    assert state.race_state == 'YELLOW'
+
+def test_set_cooldown_active(state: SessionState):
+    """Tests setting the cooldown active"""
+    state.set_cooldown_active(True)
+    assert state.cooldown_active == True
+
+def test_set_session_end_time(state: SessionState):
+    """Tests setting the session end time"""
+    end_time = time.monotonic()
+    state.set_session_end_time(end_time)
+    assert state.session_end_time == end_time
+
+def test_add_yellow_flag(state: SessionState):
+    """Tests adding a yellow flag"""
+    state.add_sector_to_yellow_flags(2)
+    assert state.yellow_flags == {2}
+
+def test_add_yellow_flag_already_exists(state: SessionState):
+    """Tests adding a yellow flag that already exists"""
+    state.yellow_flags = {2}
+    state.add_sector_to_yellow_flags(2)
+    assert state.yellow_flags == {2}
+
+def test_remove_yellow_flags(state: SessionState):
+    """Tests removing yellow flags"""
+    state.yellow_flags = {2, 3, 4}
+    state.remove_sector_from_yellow_flags(2)
+    assert state.yellow_flags == {3, 4}
+
+def test_remove_yellow_flag_not_in_set(state: SessionState):
+    """Tests removing a yellow flag that doesn't exist"""
+    state.yellow_flags = {2, 3, 4}
+    state.remove_sector_from_yellow_flags(8)
+    assert state.yellow_flags == {2, 3, 4}
+
+def test_clear_yellow_flags(state: SessionState):
+    """Tests clearing yellow flags"""
+    state.yellow_flags = {2, 3, 4}
+    state.clear_yellow_flags()
+    assert state.yellow_flags == set()
+
+def test_clear_yellow_flags_empty_set(state: SessionState):
+    """Tests clearing yellow flags when the set is empty"""
+    state.clear_yellow_flags()
+    assert state.yellow_flags == set()
+
+def test_set_session_lead(state: SessionState):
+    """Tests setting the session lead"""
+    state.set_session_lead(driver='VER', driver_number='1', team='Red Bull')
+    assert state.current_session_lead.driver == 'VER'
+    assert state.current_session_lead.driver_number == '1'
+    assert state.current_session_lead.team == 'Red Bull'
+
+def test_set_fasest_lap(state: SessionState):
+    """Tests setting the fastest lap"""
+    state.set_fastest_lap(lap_time=timedelta(minutes=1, seconds=28, microseconds=552000), driver='VER', team='Red Bull')
+    assert state.fastest_lap_info.time == timedelta(minutes=1, seconds=28, microseconds=552000)
+    assert state.fastest_lap_info.driver == 'VER'
+    assert state.fastest_lap_info.team == 'Red Bull'
+
+def test_reset_for_Q2_quali_segment(state: SessionState):
+    """Tests resetting for the next Q2 segment"""
+    state.session_type = 'qualifying'
+    state.quali_session = 'Q1'
+    state.cooldown_active = True
+    state.session_end_time = time.monotonic()
+    state.fastest_lap_info.time = timedelta(minutes=1, seconds=28, microseconds=552000)
+    state.fastest_lap_info.driver = 'VER'
+    state.fastest_lap_info.team = 'Red Bull'
+
+    state.reset_for_next_quali_segment()
+
+    assert state.quali_session == 'Q2'
+    assert state.fastest_lap_info.time == timedelta(minutes=5)
+    assert state.fastest_lap_info.driver is None
+    assert state.fastest_lap_info.team is None
+    assert state.cooldown_active is False
+    assert state.session_end_time is None
+
+def test_reset_for_Q3_quali_segment(state: SessionState):
+    """Tests resetting for the next Q3 segment"""
+    state.session_type = 'qualifying'
+    state.quali_session = 'Q2'
+    state.cooldown_active = True
+    state.session_end_time = time.monotonic()
+    state.fastest_lap_info.time = timedelta(minutes=1, seconds=28, microseconds=552000)
+    state.fastest_lap_info.driver = 'VER'
+    state.fastest_lap_info.team = 'Red Bull'
+
+    state.reset_for_next_quali_segment()
+
+    assert state.quali_session == 'Q3'
+    assert state.fastest_lap_info.time == timedelta(minutes=5)
+    assert state.fastest_lap_info.driver is None
+    assert state.fastest_lap_info.team is None
+    assert state.cooldown_active is False
+    assert state.session_end_time is None
+
+def test_set_true_session_start_time(state: SessionState):
+    """Tests setting the true session start time"""
+    start_time = time.monotonic()
+    state.set_true_session_start_time(start_time)
+    assert state.true_session_start_time == start_time
+
+
+
+
+    
+
+
+


### PR DESCRIPTION
### ADDED
- Team Color to drs_data
- Team Color to the MQTT message on leader
- Template files for the configs
- Session Caching (#10)
- Added tests for `main.py` and `session_state.py`
- Deleted lap time debug line (not used yet)

### CHANGED
- Moving business logic in `main.py` to dedicated functions (#16)
- `--Force-Lead` (`-fl`) is now **required** to provide for Races (Austin SR T1 is a great example for why the service needs to know how to reset after a Safety Car)

### REMOVED
- `config.py` from being tracked in the git repo