### PR TITLE
0.8.0 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ config.py
 ff1_cache/
 *cache.txt
 cache*.txt
+*cache.pkl
+cache*.pkl
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Livetiming API to fetch the data real time.
 
 ![HA-Automation_3](https://github.com/user-attachments/assets/1aa65c1d-8c3a-40bb-9d64-06335587a05e)
 
+See the wiki for more in-depth details.
 
 ## Features
 * Sync smart lights with the F1 broadcast leader, matching their team colors.
@@ -26,37 +27,12 @@ To put it simply: it is a tool that I use to get an exact "here and now" picture
 * Smart lights/devices configured in Home Assistant (e.g., Philips Hue to respond to the events).
 
 ### Project Files
-Before running, you must create two configuration files (easiest is to duplicate the two template files in the project and remove the `_template` suffix):
+Before running, you must create two configuration files (easiest is to duplicate the two template files in the project and remove the `_template` suffix): `mqtt_config.py` and `config.py`
 
-1. `mqtt_config.py`: Holds your MQTT broker credentials.
-```python
-MQTT_BROKER_IP = "0.0.0.0" 
-MQTT_PORT = 1883 # For unsecure communication running over local network
-MQTT_USERNAME = "service_user_name"
-MQTT_PASSWORD = "your_strong_password" # MQTT password that's also present in your Home Assistant
-```
-2. `config.py`: Contains key variables for the service.
-```python
-CACHE_FILENAME = 'cache.txt'  # Important that this matches the one Fast-F1 Livetiming writes to
-
-PUBLISH_DELAY = 54
-
-SESSION_CACHING_ENABLED = True
-SESSION_CACHING_INTERVAL = 10
-```
 
 > [!NOTE]
-> **A Note on the `PUBLISH_DELAY`**
 > 
-> You might wonder why there's a delay between the script receiving a message and publishing it to MQTT. This is the most important setting for syncing the service with what you see on screen.
->
-> The official F1 timing data, which this tool uses via the FastF1 API, often arrives many seconds (some report up to a minute!) **before** you see the corresponding action on your F1TV or television broadcast. This is due to natural broadcast and streaming delays.
-> 
->The `PUBLISH_DELAY` variable lets you add a buffer to compensate for this. By setting a delay, you ensure that when your lights change color for a new leader or a safety car, it happens at the exact moment you see it on your screen, not seconds beforehand.
->
-> You'll need to fine-tune this value based on your specific broadcast: 
-> - A good-guess starting point is often between **50 and 60 seconds.** (based on personal experience)
-> - Remember, you can adjust this delay live using the **Delay Calibration** buttons in Home Assistant once the session has started.
+> The wiki contains more in-dept description of the `PUBLISH_DELAY` system.
 
 #### Caching
 To protect against unexpected crashes or interruptions, the service includes a session caching feature.
@@ -92,9 +68,25 @@ pip install -r requirements.txt
 Create the mqtt_config.py file as described in the Requirements section above and review config.py.
 
 ## Usage
-The service requires two separate processes running in two separate terminals.
+There are 2 ways of starting the service the new `pitwall` or the old 2 terminals
 
-### 1. Start the FastF1 Live Timing Client
+### Pitwall
+In `0.8` the `pitwall.py` was introduced: one script to run both services needed. This is the simplest way of starting up DRS as it will also shut down both services if one of them fails. running the `pitwall` script requires a session type argument and accepts optional flags. When running, the service will start writing and reading from the cache file defined in `config.py` and publishing events to your MQTT broker.
+
+**Syntax**:
+```bash
+python pitwall.py <session_type> [options]
+```
+
+**Example:**
+```bash
+python pitwall.py race --force-lead "Red Bull"
+```
+
+### The Old Way
+It is still possible to start the service "the old way" where you manually start both terminals.
+
+#### 1. Start the FastF1 Live Timing Client
 In your first terminal, activate the virtual environment and run the following command. This will connect to the F1 servers and start saving live data to the cache file.
 
 ```bash
@@ -105,8 +97,9 @@ python -m fastf1.livetiming save --append cache.txt
 >    The livetiming starts broadcasting around 5 min before event start. The connection times out after
 >    60s of no broadcasts. So be aware and not start the livetiming too early as it will cut your connection.
 
-### 2. Start the DRS Service
-In a second terminal, activate the virtual environment and run the `main.py` script. The command requires a session type argument and accepts optional flags. When running, the service will start reading from `cache.txt` (or file defined in `config.py`) and publishing events to your MQTT broker.
+#### 2. Start the DRS Service
+
+In a second terminal, activate the virtual environment and run the `main.py` script. The command requires a session type argument and accepts optional flags. When running, the service will start reading from the cache file defined in `config.py` and publishing events to your MQTT broker.
 
 **Syntax**:
 ```bash

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - in `FP1` They changed yellow flags from `RaceControl` to `TrackStatus`
 - Clearing of yellow flag sectors when returning to green (as a just in case missed)
 
+### CHANGED
+- Moved session retention on shutdown to its own function
+
 ## [0.7.0] - 2025-10-18 (FREEDOM release)
 
 ### ADDED

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CHANGED
 - Moved session retention on shutdown to its own function
+- improved docstrings to following modules:
+  - `f1_utils.py`
 
 ## [0.7.0] - 2025-10-18 (FREEDOM release)
 

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [0.8.0] - 2025-11-22 (PITWALL release)
+
 ### ADDED
 - Processing of `TrackStatus`:
   - in `FP1` They changed yellow flags from `RaceControl` to `TrackStatus`
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CHANGED
 - Moved session retention on shutdown to its own function
+- Updates to `README.md` as work on moving more in-depth info into the Github Wiki has started
 - improved docstrings to following modules:
   - `f1_utils.py`
 

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Processing of `TrackStatus`:
   - in `FP1` They changed yellow flags from `RaceControl` to `TrackStatus`
 - Clearing of yellow flag sectors when returning to green (as a just in case missed)
+- A combined starter.py script (starts both livetiming and DRS)
 
 ### CHANGED
 - Moved session retention on shutdown to its own function

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### ADDED
+- Processing of `TrackStatus`:
+  - in `FP1` They changed yellow flags from `RaceControl` to `TrackStatus`
+- Clearing of yellow flag sectors when returning to green (as a just in case missed)
+
 ## [0.7.0] - 2025-10-18 (FREEDOM release)
 
 ### ADDED

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Processing of `TrackStatus`:
   - in `FP1` They changed yellow flags from `RaceControl` to `TrackStatus`
 - Clearing of yellow flag sectors when returning to green (as a just in case missed)
-- A combined starter.py script (starts both livetiming and DRS)
+- A combined starter script (starts both livetiming and DRS) called `pitwall.py`
 
 ### CHANGED
 - Moved session retention on shutdown to its own function

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -19,10 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CHANGED
 - Moving business logic in `main.py` to dedicated functions (#16)
-- `--Force-Lead` (`-fl`) is now **required** to provide for Races (Austin SR T1 is a great example for why the service needs to know how to reset after a Safety Car)
+- `--force-lead` (`-fl`) is now **required** to provide for Races (Austin SR T1 is a great example for why the service needs to know how to reset after a Safety Car)
 
 ### REMOVED
 - `config.py` from being tracked in the git repo
+
+### FIXED
+- `--force-lead` being very fragile in the accepted inputs.
 
 ## [0.6.2] - 2025-10-11
 

--- a/docs/debug_lines.md
+++ b/docs/debug_lines.md
@@ -38,13 +38,24 @@ Note their sectors when pairing with CLEAR flags
 ['RaceControlMessages', {'Messages': {'56': {'Utc': '2025-07-05T11:39:56', 'Category': 'Flag', 'Flag': 'YELLOW', 'Scope': 'Sector', 'Sector': 2, 'Message': 'YELLOW IN TRACK SECTOR 2'}}}, '2025-07-05T11:39:56.262Z']
 ['RaceControlMessages', {'Messages': {'4': {'Utc': '2025-07-04T15:16:09', 'Category': 'Flag', 'Flag': 'DOUBLE YELLOW', 'Scope': 'Sector', 'Sector': 8, 'Message': 'DOUBLE YELLOW IN TRACK SECTOR 8'}}}, '2025-07-04T15:16:09.257Z']
 
+As of Mexican Grand Prix this was used for Yellow Flag:
+['TrackStatus', {'Status': '2', 'Message': 'Yellow', '_kf': True}, '2025-10-24T19:10:17.604Z']
+
+
 ### CLEAR FLAGS
 Used for clearing sectors for yellow flags (they never show a GREEN flag)
 ['RaceControlMessages', {'Messages': {'13': {'Utc': '2025-09-06T14:22:44', 'Category': 'Flag', 'Flag': 'CLEAR', 'Scope': 'Sector', 'Sector': 8, 'Message': 'CLEAR IN TRACK SECTOR 8'}}}, '2025-09-06T14:22:43.772Z']
 ['RaceControlMessages', {'Messages': {'13': {'Utc': '2025-09-06T14:22:44', 'Category': 'Flag', 'Flag': 'CLEAR', 'Scope': 'Sector', 'Sector': 2, 'Message': 'CLEAR IN TRACK SECTOR 8'}}}, '2025-09-06T14:22:43.772Z']
 
+From Mexico GP:
+['TrackStatus', {'Status': '1', 'Message': 'AllClear', '_kf': True}, '2025-10-24T18:45:45.052Z']
+
+
 ### RED Flag
 ['RaceControlMessages', {'Messages': {'50': {'Utc': '2025-07-05T11:33:58', 'Category': 'Flag', 'Flag': 'RED', 'Scope': 'Track', 'Message': 'RED FLAG'}}}, '2025-07-05T11:33:58.102Z']
+
+Based on yellow flag in Mexican GP, this is a guestimate:
+['TrackStatus', {'Status': '2', 'Message': 'Red', '_kf': True}, '2025-10-24T19:10:17.604Z']
 
 ### CHEQUERED Flag
 ['RaceControlMessages', {'Messages': {'14': {'Utc': '2025-07-05T14:27:49', 'Category': 'Flag', 'Flag': 'CHEQUERED', 'Scope': 'Track', 'Message': 'CHEQUERED FLAG'}}}, '2025-07-05T14:27:49.153Z']

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from src.drs.mqtt_handler import MQTTHandler
 from src.drs.mqtt_topics import MqttTopics
 import src.drs.session_caching as session_caching
 
-DRS_VERSION = "0.7.0"
+DRS_VERSION = "0.7.1 ALPHA MEXICO"
 
 SESSION_MAP = {
     'p' : 'practice',
@@ -127,6 +127,7 @@ def main_loop(session_state:SessionState, mqtt: MQTTHandler, command_queue: queu
                     f1_utils.process_session_data_line(line, session_state, mqtt)
                     race_lead_process(line, session_state, mqtt)
                     f1_utils.process_race_control_line(line, session_state, mqtt)
+                    f1_utils.process_track_status_line(line, session_state, mqtt)
                 except Exception as e:
                     logging.error(f"Error processing line: {e}")
 

--- a/main.py
+++ b/main.py
@@ -57,6 +57,9 @@ def handle_shutdown_caching(session_sate: SessionState):
         if retain_cache != 'y':
             session_caching.delete_state_cache()
 
+    except KeyboardInterrupt:
+        logging.warning(f'Keyboard interrupt')
+
     except Exception as e:
         logging.error(f"Error during shutdown caching: {e}")
 

--- a/main.py
+++ b/main.py
@@ -47,6 +47,19 @@ def handle_periodic_caching(current_state: SessionState, last_cached_state: Sess
     
     return last_cached_state, last_cached_time
 
+def handle_shutdown_caching(session_sate: SessionState):
+    """Handles KeyboardInterupt caching based on input"""
+    try:
+        session_caching.save_state(session_sate)
+
+        retain_cache = input("Do you want to retain the session cache (do not keep if session is done)? (y/n): ").lower()
+
+        if retain_cache != 'y':
+            session_caching.delete_state_cache()
+
+    except Exception as e:
+        logging.error(f"Error during shutdown caching: {e}")
+
 
 def load_drs_data(filename : str = "drs_data.json") -> dict:
     """Loads the static F1 driver and team data from the JSON file"""
@@ -204,12 +217,9 @@ if __name__ == "__main__":
     try:
         main_loop(session_state, mqtt, command_queue)
     except KeyboardInterrupt:
-        session_caching.save_state(session_state)
+        handle_shutdown_caching(session_state)
         logging.info("Service stopped by user.")
         logging.shutdown()
-        retain_cache = input("Do you want to retain the session cache (do not keep if session is done)? (y/n): ").lower()
-        if retain_cache != 'y':
-            session_caching.delete_state_cache()
     except FileNotFoundError:
         logging.error(f"[FATAL] Data file not found: {CACHE_FILENAME}")
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from src.drs.mqtt_handler import MQTTHandler
 from src.drs.mqtt_topics import MqttTopics
 import src.drs.session_caching as session_caching
 
-DRS_VERSION = "0.7.1 ALPHA MEXICO"
+DRS_VERSION = "0.8.0 PITWALL"
 
 SESSION_MAP = {
     'p' : 'practice',

--- a/pitwall.py
+++ b/pitwall.py
@@ -1,3 +1,4 @@
+"""A combined starter script that runs both livetiming and the DRS"""
 import subprocess
 import sys
 import os
@@ -87,19 +88,6 @@ if __name__ == "__main__":
                 logging.info(f"Terminating Livetiming due to main.py shutdown")
                 p1.terminate()
                 p1.wait()
-
-        # while p2.poll is None:
-        #     if p1.poll() is not None:
-        #         # FastF1 died (or most likely broke connection)
-        #         logging.error(f"FastF1 livetiming has cut off!")
-        #         _, stderr_output = p1.communicate()
-        #         if stderr_output:
-        #             logging.error(f"FastF1 stderr:\n{stderr_output.decode()}")
-        #         break
-
-        #     time.sleep(0.5)
-
-        # logging.info(f"main.py process exited with code {p2.poll()}.")
     
     except KeyboardInterrupt:
         logging.info("\nKeyboard interrupt received. Initiating shutdown...")
@@ -112,12 +100,7 @@ if __name__ == "__main__":
 
         if p2 and p2.poll() is None:
             try:
-                if os.name == 'nt':
-                    p2.send_signal(signal.CTRL_C_EVENT)
-                else:
-                    p2.send_signal(signal.SIGINT)
-
-                p2.wait()
+                p2.wait() # Wait for the user input on caching
                 logging.info('main.py has exited.')
             except Exception as e:
                 logging.warning(f'Error signaling main.py: {e}. Falling back to cleanup.')

--- a/src/drs/f1_utils.py
+++ b/src/drs/f1_utils.py
@@ -9,13 +9,39 @@ from .mqtt_topics import MqttTopics
 from .session_state import SessionState
 
 def rebroadcast_leader(state: SessionState, mqtt_handler: MQTTHandler) -> None:
-    """Resends the lead, usefull after flag or Safety Car events"""
+    """Resends the current leader's info to MQTT.
+
+    Useful after a flag or Safety Car event. This function was created 
+    because Home Assistant had difficulty relying *only* on the 'GREEN' 
+    flag event to correctly revert lights to the race leader's colors.
+
+    The function will return early if no `current_session_lead.team` is 
+    set in the state. This can happen if an event (e.g., double yellow)
+    occurs before any fastest lap is set in Practice or Qualifying.
+
+    Args:
+        state: The current SessionState, used to read leader info.
+        mqtt_handler: The MQTTHandler instance to queue the message.
+    """
     if not state.current_session_lead.team: return #Early return if no leader has been set
     payload = json.dumps({"driver": state.current_session_lead.driver, "driver_number": state.current_session_lead.driver_number, "team": state.current_session_lead.team})
     mqtt_handler.queue_message(MqttTopics.LEADER_TOPIC, payload)
 
 def return_to_green(state: SessionState, mqtt_handler: MQTTHandler, payload_message: str) -> None:
-    """Returns the session to GREEN flag status"""
+    """Sets the session to a GREEN flag status and notifies MQTT.
+
+    This function performs several actions:
+    1. Sets the `race_state` in the SessionState to "GREEN".
+    2. Clears all active yellow flag sectors.
+    3. Publishes the new GREEN flag status to the `FLAG_TOPIC`.
+    4. Calls `rebroadcast_leader` to resend the current leader's info.
+
+    Args:
+        state: The current SessionState object to be modified.
+        mqtt_handler: The MQTTHandler instance to queue messages.
+        payload_message: The descriptive message (e.g., "ALL CLEAR") 
+                         to send with the GREEN flag payload.
+    """
     logging.info(f'Returning to GREEN flag status from {state.race_state}')
     state.set_race_state("GREEN")
     state.clear_yellow_flags()
@@ -24,7 +50,15 @@ def return_to_green(state: SessionState, mqtt_handler: MQTTHandler, payload_mess
     rebroadcast_leader(state, mqtt_handler)
 
 def parse_lap_time(time_str: str) -> timedelta | None:
-    """Converts a time string to a timedelta object"""
+    """Converts a "M:SS.fff" time string into a timedelta object.
+
+    Args:
+        time_str: The lap time string (e.g., "1:34.567").
+
+    Returns:
+        A timedelta object representing the lap time, or None if
+        parsing fails (e.g., due to ValueError or invalid format).
+    """
     if not (isinstance(time_str, str) or ':' not in time_str):
         return None
     try:
@@ -38,6 +72,27 @@ def parse_lap_time(time_str: str) -> timedelta | None:
         return None
 
 def process_lap_time_line(line: str, state: SessionState, mqtt_handler: MQTTHandler) -> None:
+    """Processes a 'TimingData' line to find a new fastest lap.
+
+    This function is used in Practice and Qualifying to determine the
+    session leader based on the fastest lap time.
+
+    The process is as follows:
+    1. Checks if the line `category` is 'TimingData'.
+    2. Parses the lap time string and compares it to the current 
+       fastest lap in `state.fastest_lap_info`.
+    3. If a new fastest lap is set:
+       a. Extracts driver and team info using the driver number.
+       b. Sets 'UNK' (UNKNOWN) if driver/team data is missing.
+       c. Updates the `SessionState` with the new fastest lap and
+          sets the new `current_session_lead`.
+       d. Queues a message to the `LEADER_TOPIC` with the new leader's info.
+
+    Args:
+        line: The raw data line (as a string) from the cache file.
+        state: The current SessionState object to be modified.
+        mqtt_handler: The MQTTHandler instance to queue messages.
+    """
     category, payload, _ = ast.literal_eval(line)
 
     if category == 'TimingData' and 'Lines' in payload:
@@ -62,6 +117,23 @@ def process_lap_time_line(line: str, state: SessionState, mqtt_handler: MQTTHand
                     mqtt_handler.queue_message(MqttTopics.LEADER_TOPIC, payload)
 
 def process_race_lead_line(line: str, state: SessionState, mqtt_handler: MQTTHandler) -> None:
+    """Processes a 'TopThree' line to find a new leader.
+
+    This function is used in Race to determine the race lead.
+
+    The process is as follows:
+    1. Checks if the line `category` is 'TopThree' AND it involves
+       the first place ('0').
+    2. Extracts driver and team info using the driver number.
+        a. Sets 'UNK' (UNKNOWN) if driver/team data is missing.
+    3. Updates the `SessionState` with the new `current_session_lead`.
+    4. Queues a message to the `LEADER_TOPIC` with the new leader's info.
+
+    Args:
+        line: The raw data line (as a string) from the cache file.
+        state: The current SessionState object to be modified.
+        mqtt_handler: The MQTTHandler instance to queue messages.
+    """
     category, payload, _ = ast.literal_eval(line)
     if category == 'TopThree' and 'Lines' in payload and '0' in payload['Lines']:
         p1_data = payload['Lines']['0']
@@ -86,7 +158,42 @@ def process_race_lead_line(line: str, state: SessionState, mqtt_handler: MQTTHan
             mqtt_handler.queue_message(MqttTopics.LEADER_TOPIC, payload)
 
 def process_race_control_line(line: str, state: SessionState, mqtt_handler: MQTTHandler) -> None:
-    """Evaluates Race Control Lines, these include Flags and Safety Cars"""
+    """Processes 'RaceControlMessage' lines for flags and safety cars.
+
+    This function parses messages from the 'RaceControlMessages' category,
+    which can be sent during any session type. It is responsible for
+    updating the session state based on on-track events.
+
+    The function first checks for a valid 'RaceControlMessages' payload.
+    It then dispatches logic based on the message category, primarily
+    handling Flag and Safety Car events.
+
+    **Flag Events:**
+    - **RED:** Sets the `race_state` to "RED", clears all yellow flags, 
+      and broadcasts the new RED flag state.
+    - **YELLOW:** Adds the specified sector to the `yellow_flags` set.
+      If the state was not already 'YELLOW', it updates the `race_state` 
+      and broadcasts the YELLOW flag.
+    - **CLEAR:** Removes the specified sector from the `yellow_flags` set.
+      If the `yellow_flags` set is now empty, it calls 
+      `return_to_green()`.
+    - **CHEQUERED:** In Qualifying sessions, this activates the 
+      `cooldown_active` flag and records the `session_end_time` to
+      manage the break between quali segments.
+
+    **Safety Car Events:**
+    - **DEPLOYED:** (Used for both VSC and full Safety Car)
+      Sets the `race_state` to "SAFETY CAR", clears all yellow flags,
+      and broadcasts the SAFETY CAR status.
+    - **ENDING / IN THIS LAP:** (Used for VSC Ending or SC In)
+      Calls `return_to_green()` to return the session to normal 
+      racing conditions.
+
+    Args:
+        line: The raw data line (as a string) from the cache file.
+        state: The current SessionState object to be modified.
+        mqtt_handler: The MQTTHandler instance to queue messages.
+    """
     category, payload, _ = ast.literal_eval(line)
 
     if category == 'RaceControlMessages' and 'Messages' in payload:
@@ -137,7 +244,26 @@ def process_race_control_line(line: str, state: SessionState, mqtt_handler: MQTT
                     return_to_green(state, mqtt_handler, "SAFETY CAR ENDING")
 
 def process_session_data_line(line:str, state: SessionState, mqtt_handler: MQTTHandler) -> None:
-    """Processing the Session Data Lines, like session start and red flag restarts"""
+    """Processing the 'SessionData' Lines for starts/restarts. 
+    
+    Both session starts and restarts from a red flag is broadcasted similarly.'
+    This function operates in two ways:
+
+    A: If the SessionState has not discovered a 'true start time' this will trigger
+       the timer for this, and set the true_session_start_time. This is used for the
+       calibration feedback the user can use.
+    B: Or if the a true start *has* been discovered and we're in a 'RED' race_state
+       it is used to call the return_to_green function.
+
+    There is a chance that yellow flags are done similarly, but this needs a lot
+    more testing/checking in the data to figure out, but if so could greatly simplify
+    the way yellow flags are handled.
+    
+    Args:
+        line: The raw data line (as a string) from the cache file.
+        state: The current SessionState object to be modified.
+        mqtt_handler: The MQTTHandler instance to queue messages.
+    """
     try:
         category, payload, _ = ast.literal_eval(line)
     except (ValueError, SyntaxError):
@@ -155,7 +281,24 @@ def process_session_data_line(line:str, state: SessionState, mqtt_handler: MQTTH
                     break
 
 def process_track_status_line(line: str, state: SessionState, mqtt_handler: MQTTHandler) -> None:
-    """Processing Track Status Lines, appereantly like 'Yellow' and 'AllClear'"""
+    """Processing 'TrackStatus' lines for track events.
+
+    This popped up during the FP1 session of the 2025 Mexico Grand Prix
+    and seemed to be a simpler form of the 'RaceControlMessages'
+
+    **YELLOW**: Sets the race state to YELLOW if we're in green conidition
+                and broadcasts the 'YELLOW' flag. No info about sectors.
+    **RED**: Sets the race state to RED, clears any yellow flags and 
+             broadcasts the 'RED' flag. There were no red flags during the
+             session so I am just guessing this is how red flags are 
+             communicated.
+    **CLEAR**: Returns the sesssion to green if it isn't so already
+    
+    Args:
+        line: The raw data line (as a string) from the cache file.
+        state: The current SessionState object to be modified.
+        mqtt_handler: The MQTTHandler instance to queue messages.
+    """
     try:
         category, payload, _ = ast.literal_eval(line)
     except (ValueError, SyntaxError):

--- a/src/drs/f1_utils.py
+++ b/src/drs/f1_utils.py
@@ -18,6 +18,7 @@ def return_to_green(state: SessionState, mqtt_handler: MQTTHandler, payload_mess
     """Returns the session to GREEN flag status"""
     logging.info(f'Returning to GREEN flag status from {state.race_state}')
     state.set_race_state("GREEN")
+    state.clear_yellow_flags()
     payload = json.dumps({"flag": "GREEN", "message": payload_message})
     mqtt_handler.queue_message(MqttTopics.FLAG_TOPIC, payload)
     rebroadcast_leader(state, mqtt_handler)
@@ -152,3 +153,29 @@ def process_session_data_line(line:str, state: SessionState, mqtt_handler: MQTTH
                 elif state.race_state == 'RED':
                     return_to_green(state, mqtt_handler, "GREEN FLAG, RED flag cleared")
                     break
+
+def process_track_status_line(line: str, state: SessionState, mqtt_handler: MQTTHandler) -> None:
+    """Processing Track Status Lines, appereantly like 'Yellow' and 'AllClear'"""
+    try:
+        category, payload, _ = ast.literal_eval(line)
+    except (ValueError, SyntaxError):
+        return
+    
+    if category == 'TrackStatus':
+        logging.info(f'Found track status line!')
+        msg = payload.get('Message', None)
+        # 🟡 YELLOW FLAGS 🟡
+        if msg == 'Yellow' and state.race_state == 'GREEN':
+            state.set_race_state('YELLOW')
+            mqtt_payload = json.dumps({"flag": 'YELLOW', "message": 'YELLOW FLAG ON TRACK!'})
+            mqtt_handler.queue_message(MqttTopics.FLAG_TOPIC, mqtt_payload)
+        # 🚩 RED FLAGS 🚩
+        elif msg == 'Red':
+            state.set_race_state('RED')
+            state.clear_yellow_flags()
+            mqtt_payload = json.dumps({"flag": 'RED', "message": 'RED FLAG ON TRACK!'})
+            mqtt_handler.queue_message(MqttTopics.FLAG_TOPIC, mqtt_payload)
+        # 👍 CLEAR Flags 👍
+        elif msg == 'AllClear' and state.race_state != 'GREEN':
+            return_to_green(state, mqtt_handler, 'TRACK CLEAR RETURN TO GREEN!')
+

--- a/start.py
+++ b/start.py
@@ -1,0 +1,128 @@
+import subprocess
+import sys
+import os
+import time
+import atexit
+import logging
+import signal
+
+try:
+ from config import CACHE_FILENAME
+except ImportError:
+    logging.warning(f'Could not import CACHE_FILENAME from config.py. Defulting to "cache.txt"')
+    CACHE_FILENAME = 'cache.txt'
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+processes = []
+
+def cleanup_process():
+    """Terminates all child processes gracefully"""
+    logging.info("Shutting down child processes...")
+    for p in processes:
+        if p.poll() is None:
+            try:
+                p.terminate()
+                logging.info(f"Terminated process")
+            except Exception as e:
+                logging.warning(f"Could not terminate {p.pid}: {e}")
+
+    # Wait for a sec for graceful shutdown
+    time.sleep(1)
+
+    for p in processes:
+        if p.poll() is None: # Time to keep more heavy handed
+            try:
+                p.kill()
+                logging.warning(f"Killed process {p.pid}")
+            except Exception as e:
+                logging.error(f"Could not kill {p.pid}: {e}")
+
+atexit.register(cleanup_process)
+
+p1 = None
+p2 = None
+
+if __name__ == "__main__":
+    try:
+        python_exe = sys.executable
+
+        logging.info("Starting FastF1 livetiming")
+        cmd1 = [python_exe, "-m", "fastf1.livetiming", "save", "--append", CACHE_FILENAME]
+        p1 = subprocess.Popen(cmd1, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        processes.append(p1)
+
+        time.sleep(3)
+
+        main_py_args = sys.argv[1:]
+        logging.info(f"Starting main.py with args: {' '.join(main_py_args)}")
+        cmd2 = [python_exe, "main.py"] + main_py_args
+        creationflags = 0
+        if os.name == "nt":
+            creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+
+        p2 = subprocess.Popen(cmd2)
+        processes.append(p2)
+
+        while p1.poll() is None and p2.poll() is None:
+            time.sleep(0.5)
+
+        if p1.poll() is not None:
+            p1_code = p1.poll()
+            logging.error(f"FastF1 livetiming terminated with code {p1_code}")
+            stderr_output = p1.stderr.read()
+            if stderr_output:
+                logging.error(f"FastF1 stderr:\n{stderr_output.decode().strip()}")
+
+            if p2.poll() is None:
+                logging.info(f"Terminating main.py due to livetiming shutdown")
+                p2.terminate()
+                p2.wait()
+
+        elif p2.poll() is not None:
+            p2_code = p2.poll()
+            logging.error(f"main.py terminated with code {p2_code}")
+
+            if p1.poll() is None:
+                logging.info(f"Terminating Livetiming due to main.py shutdown")
+                p1.terminate()
+                p1.wait()
+
+        # while p2.poll is None:
+        #     if p1.poll() is not None:
+        #         # FastF1 died (or most likely broke connection)
+        #         logging.error(f"FastF1 livetiming has cut off!")
+        #         _, stderr_output = p1.communicate()
+        #         if stderr_output:
+        #             logging.error(f"FastF1 stderr:\n{stderr_output.decode()}")
+        #         break
+
+        #     time.sleep(0.5)
+
+        # logging.info(f"main.py process exited with code {p2.poll()}.")
+    
+    except KeyboardInterrupt:
+        logging.info("\nKeyboard interrupt received. Initiating shutdown...")
+
+        if p1 and p1.poll() is None:
+            try:
+                p1.terminate()
+            except Exception as e:
+                logging.warning(f"Could not terminate p1: {e}")
+
+        if p2 and p2.poll() is None:
+            try:
+                if os.name == 'nt':
+                    p2.send_signal(signal.CTRL_C_EVENT)
+                else:
+                    p2.send_signal(signal.SIGINT)
+
+                p2.wait()
+                logging.info('main.py has exited.')
+            except Exception as e:
+                logging.warning(f'Error signaling main.py: {e}. Falling back to cleanup.')
+                    
+    except Exception as e:
+        logging.error(f"An unexpected error occured in start.py: {e}")
+    finally:
+        logging.info("Exiting starter script.")

--- a/tests/test_f1_utils.py
+++ b/tests/test_f1_utils.py
@@ -6,7 +6,12 @@ import json
 from datetime import timedelta
 import time
 
-from src.drs.f1_utils import process_session_data_line, process_race_control_line, process_race_lead_line, process_lap_time_line
+from src.drs.f1_utils import \
+    process_session_data_line, \
+    process_race_control_line, \
+    process_race_lead_line, \
+    process_lap_time_line, \
+    process_track_status_line
 from src.drs.mqtt_topics import MqttTopics
 from src.drs.session_state import SessionState
 
@@ -413,9 +418,7 @@ class TestProcessRaceLeadLine:
 
 
     def test_process_race_lead_line_no_p1_data(self, mock_mqtt, state):
-        """
-        Test that the function handles 'TopThree' data that is missing the P1 ('0') key.
-        """
+        """Test that the function handles 'TopThree' data that is missing the P1 ('0') key."""
         line = "['TopThree', {'Lines': {'1': {'RacingNumber': '6', 'Tla': 'HAD', 'BroadcastName': 'I HADJAR', 'FullName': 'Isack HADJAR', 'FirstName': 'Isack', 'LastName': 'Hadjar', 'Reference': 'ISAHAD01', 'Team': 'Racing Bulls', 'TeamColour': '6C98FF', 'LapState': 33}}}, '2025-09-20T12:00:46.302Z']"
         state_before = dataclasses.replace(state)
 
@@ -424,4 +427,39 @@ class TestProcessRaceLeadLine:
         assert state_before == state
         mock_mqtt.queue_message.assert_not_called()
 
+class TestTrackStatusLine:
+    """Pretty new to check after Mexico GP FP1"""
+    def test_track_status_not_changing_green_to_green(self, state: SessionState, mock_mqtt: Mock):
+        """Tests that nothing changes on track clear while in GREEN"""
+        clear_track_line = "['TrackStatus', {'Status': '1', 'Message': 'AllClear', '_kf': True}, '2025-10-24T18:45:45.052Z']"
 
+        process_track_status_line(clear_track_line, state, mock_mqtt)
+
+        assert state.race_state == 'GREEN'
+        mock_mqtt.queue_message.assert_not_called()
+
+    def test_track_status_green_to_yellow(self, mock_mqtt: Mock, state: SessionState):
+        """Tests that the track status goes to yellow (new from Mexico GP)"""
+        yellow_flag_line = "['TrackStatus', {'Status': '2', 'Message': 'Yellow', '_kf': True}, '2025-10-24T19:10:17.604Z']"
+
+        process_track_status_line(yellow_flag_line, state, mock_mqtt)
+
+        # ASSERT
+        assert state.race_state == 'YELLOW'
+        mock_mqtt.queue_message.assert_called_once()
+        excepted_payload = json.dumps({"flag": "YELLOW", "message": "YELLOW FLAG ON TRACK!"})
+        mock_mqtt.queue_message.assert_called_with(MqttTopics.FLAG_TOPIC, excepted_payload)
+
+    def test_track_status_yellow_to_green(self, state: SessionState, mock_mqtt: Mock):
+        """Tests that the track status goes from yellow to green"""
+        state.set_race_state('YELLOW')
+
+        clear_track_line = "['TrackStatus', {'Status': '1', 'Message': 'AllClear', '_kf': True}, '2025-10-24T18:45:45.052Z']"
+
+        process_track_status_line(clear_track_line, state, mock_mqtt)
+
+        # ASSERT
+        assert state.race_state == 'GREEN'
+        mock_mqtt.queue_message.assert_called_once()
+        expected_payload = json.dumps({"flag": "GREEN", "message": "TRACK CLEAR RETURN TO GREEN!"})
+        mock_mqtt.queue_message.assert_called_with(MqttTopics.FLAG_TOPIC, expected_payload)


### PR DESCRIPTION
# ADDED
- Processing of `TrackStatus`:
  - in `FP1` They changed yellow flags from `RaceControl` to `TrackStatus`
- Clearing of yellow flag sectors when returning to green (as a just in case missed)
- A combined starter script (starts both livetiming and DRS) called `pitwall.py`

# CHANGED
- Moved session retention on shutdown to its own function
- Updates to `README.md` as work on moving more in-depth info into the Github Wiki has started
- improved docstrings to following modules:
  - `f1_utils.py`